### PR TITLE
Add dots filter

### DIFF
--- a/filters.hh
+++ b/filters.hh
@@ -5,6 +5,7 @@
 #include <map>
 #include <utility>
 #include <vector>
+#include <SDL.h>
 #include <stdint.h> // for uint8_t
 #include <stdlib.h> // for rand()
 
@@ -44,13 +45,14 @@ struct FilterParameters {
 enum Filter {
     Grayscale,
     Invert,
+    Dots,
     Saturation,
     Outline,
     Mosaic,
     ChannelOffset,
     Crt,
     Voronoi,
-    Thinning
+    Thinning,
 };
 
 int correctRGB(int channel);
@@ -65,5 +67,6 @@ void channelOffset(unsigned char* imageData, unsigned char* sourceImageCopy, int
 void crt(unsigned char* imageData, unsigned char* sourceImageCopy, int imageWidth, int imageHeight, FilterParameters& params);
 void voronoi(unsigned char* imageData, int pixelDataLen, int width, int height, FilterParameters& params);
 void thinning(unsigned char* imageData, int pixelDataLen, int width, int height, FilterParameters& params);
+void dots(unsigned char* pixelData, int pixelDataLen, int imageWidth, int imageHeight, SDL_Renderer* renderer);
 
 #endif

--- a/imgui.ini
+++ b/imgui.ini
@@ -5,7 +5,7 @@ Collapsed=0
 
 [Window][App]
 Pos=0,0
-Size=1080,720
+Size=806,652
 Collapsed=0
 
 [Window][message]

--- a/utils.hh
+++ b/utils.hh
@@ -91,6 +91,14 @@ void incrementGifFrameIndex(ReconstructedGifFrames& gifFrames, int totalNumFrame
 int extractFrameDelay(SavedImage& frame);
 
 void setFilter(Filter filter, std::map<Filter, bool>& filtersWithParams,  int imageWidth, int imageHeight);
-void doFilter(int imageWidth, int imageHeight, Filter filter, FilterParameters& filterParams, bool isGif, ReconstructedGifFrames& gifFrames);
+void doFilter(
+    int imageWidth,
+    int imageHeight,
+    Filter filter,
+    FilterParameters& filterParams,
+    bool isGif,
+    ReconstructedGifFrames& gifFrames,
+    SDL_Renderer* renderer=nullptr
+);
 
 #endif


### PR DESCRIPTION
Adding a new filter that kinda turns an image into dots (but they're connected lol). 

![image](https://github.com/syncopika/imgui_image_editor/assets/8601582/407857de-f515-4bf1-a200-fc740523aaf0)

I tried to make it like how I did it in https://github.com/syncopika/funSketch/blob/master/src/filters/dots.js but it seems to be much harder in SDL2 since it's not easy to specify a point width (and the points are really square since it seems to be corresponding to a single pixel). but it's kinda there I guess 🤷?

should be a fun problem to revisit if I get a chance :)